### PR TITLE
Hotfix: typo 수정

### DIFF
--- a/colab/14-colab.ipynb
+++ b/colab/14-colab.ipynb
@@ -84,7 +84,7 @@
     "            pos_enc[pos, i] = np.sin(pos / (10000 ** (2 * i / d_model))) # 짝수 인덱스\n",
     "            if i + 1 < d_model:\n",
     "                pos_enc[pos, i + 1] = np.cos(pos / (10000 ** (2 * (i + 1) / d_model))) # 홀수 인덱스\n",
-    "\n",
+    "    return pos_enc\n",
     "# 포지셔널 인코딩 생성\n",
     "positional_encoding = get_positional_encoding(max_len, embedding_dim)\n"
    ]


### PR DESCRIPTION
안녕하세요 강사님 

패스트캠퍼스 강의 잘 보고 있습니다. 실습 코드가 있어서 개념 이해가 더 잘 되는 것 같습니다 :-) 
트랜스포머 관련 ipynb에서 리턴 값이 빠져있어서 이를 수정한 PR을 올립니다.